### PR TITLE
Update Skia version to remove vulnerability

### DIFF
--- a/Versions.prop
+++ b/Versions.prop
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftMauiGraphicsVersion>6.0.300-rc.3.1336</MicrosoftMauiGraphicsVersion>
+    <MicrosoftMauiGraphicsVersion>8.0.0-rc.2.9373</MicrosoftMauiGraphicsVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
-    <SkiaSharpVersion>2.88.0</SkiaSharpVersion>
+    <SkiaSharpVersion>2.88.6</SkiaSharpVersion>
   </PropertyGroup>
 </Project>

--- a/Versions.prop
+++ b/Versions.prop
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftMauiGraphicsVersion>8.0.0-rc.2.9373</MicrosoftMauiGraphicsVersion>
+    <MicrosoftMauiGraphicsVersion>6.0.300-rc.3.1336</MicrosoftMauiGraphicsVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <SkiaSharpVersion>2.88.6</SkiaSharpVersion>
   </PropertyGroup>

--- a/src/Tizen.UIExtensions.NUI/Tizen.UIExtensions.NUI.csproj
+++ b/src/Tizen.UIExtensions.NUI/Tizen.UIExtensions.NUI.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Graphics" Version="$(MicrosoftMauiGraphicsVersion)" />
     <PackageReference Include="Microsoft.Maui.Graphics.Skia" Version="$(MicrosoftMauiGraphicsVersion)" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('tizen')) == true">


### PR DESCRIPTION
This PR updates following Skia version to remove security vulnerability.

```csproj
  <ItemGroup>
    <PackageReference Include="Microsoft.Maui.Graphics" Version="$(MicrosoftMauiGraphicsVersion)" />
    <PackageReference Include="Microsoft.Maui.Graphics.Skia" Version="$(MicrosoftMauiGraphicsVersion)" />
  </ItemGroup>
```

### Background ###
(https://github.com/dotnet/maui/pull/17558)
About 3 weeks ago, security vulnerability is detected for `SkiaSharp.Views` and any project referencing this package is warned for the security vulnerability.
The vulnerability is patched in `SkiaSharp v2.88.6` and `Microsoft.Maui.Graphics` is now released with it on `v8.0.0-rc.2.9373`.

### What to do next? ###
  - Release `Tizen.UIExtensions` (eg. v0.9.1)
  - Update `Tizen.UIExtensions` on `MAUI`.
  - Remove `SkiaSharp.Views` direct reference from `CommunityToolkit.Maui` which was the workaround for Tizen.